### PR TITLE
enhanced error details

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,10 @@
 node_modules
 node_modules/**/*
+npm-debug.log
 .DS_Store
 tmp/**/*
 .idea
 .idea/**/*
 *.iml
 *.log
-examples/keys.json
+.nyc_output

--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,10 @@
 node_modules
+node_modules/**/*
 npm-debug.log
-examples/keys.json
+.DS_Store
+tmp/**/*
+.idea
+.idea/**/*
+*.iml
+*.log
+.nyc_output

--- a/lib/error.js
+++ b/lib/error.js
@@ -16,14 +16,17 @@ const isObject = require('lodash.isobject');
 
 module.exports = function (message, problem) {
     this.message = '';
-    this.problem = {};
+    this.details = [];
 
     if (isObject(problem)) {
-        this.problem = problem;
+        this.details.push(problem);
     }
 
     if (isError(message)) {
         this.message = message.message;
+        if (Array.isArray(message.details)) {
+            this.details = this.details.concat(message.details);
+        }
         Error.captureStackTrace(message);
         return;
     }

--- a/lib/error.js
+++ b/lib/error.js
@@ -9,7 +9,7 @@ const isObject = require('lodash.isobject');
 /**
   * Generic Error object constructor
   *
-  * @param {String} message A message to append to the Error Object
+  * @param {String|Error} message A message to append to the Error Object or an existing Error Object
   * @param {Object} problem An  message to append to the Error Object
   * @returns {this}
   */

--- a/lib/main.js
+++ b/lib/main.js
@@ -22,7 +22,7 @@ Object.keys(defs).forEach((name) => {
 
 
     module.exports[fnName].prototype.issue = function (key, value) {
-        this.problem[key] = value;
+        this.details[key] = value;
         return this;
     }
 });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "error-obj",
   "main": "./lib/main.js",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": "Amedia Utvikling",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "devDependencies": {
     "eslint": "2.8.0",
+    "joi": "8.0.5",
     "tap": "5.7.1"
   }
 }

--- a/test/error.js
+++ b/test/error.js
@@ -9,7 +9,7 @@ tap.test('constructor() - create new object with no values - should hold default
     let e = new Err();
     t.type(e, 'object');
     t.equals(e.message, '');
-    t.type(e.problem, 'object');
+    t.equals(e.details.length, 0);
     t.end();
 });
 
@@ -28,9 +28,10 @@ tap.test('constructor() - create new object with a String for "message" - should
 });
 
 
-tap.test('constructor() - create new object with a Object for "problem" - should set value on "problem"', (t) => {
+tap.test('constructor() - create new object with a Object for "problem" - should set value on "details"', (t) => {
     let e = new Err('Test Message', {test : 'test'});
-    t.equals(e.problem.test, 'test');
+    t.equals(e.details.length, 1);
+    t.equals(e.details[0].test, 'test');
     t.end();
 });
 

--- a/test/joi.js
+++ b/test/joi.js
@@ -1,0 +1,58 @@
+"use strict";
+
+const tap   = require('tap'),
+      joi   = require('joi'),
+      error = require('../');
+
+
+
+const schemaA = joi.string().label('a');
+const schemaB = joi.number().label('b');
+const schemaC = joi.object().keys({
+    a : schemaA,
+    b : schemaB
+}).label('c');
+
+
+
+tap.test('joi - pass joi error to an validationError error - "name" should be "ValidationError"', (t) => {
+    joi.validate(10, schemaA, (err, result) => {
+        let e = new error.validationError(err);
+        t.equals(e.name, 'ValidationError');
+        t.end();
+    });
+});
+
+
+tap.test('joi - pass joi error to an notFoundError error - "name" should be "NotFoundError"', (t) => {
+    joi.validate(10, schemaA, (err, result) => {
+        let e = new error.notFoundError(err);
+        t.equals(e.name, 'NotFoundError');
+        t.end();
+    });
+});
+
+
+tap.test('joi - pass joi error - single validation - "details" should match those from joi', (t) => {
+    joi.validate(10, schemaA, (err, result) => {
+        let e = new error.validationError(err);
+        t.equals(e.details.length, 1);
+        t.equals(e.details[0].message, '"a" must be a string');
+        t.equals(e.details[0].path, 'a');
+        t.equals(e.details[0].type, 'string.base');
+        t.equals(e.details[0].context.value, 10);
+        t.equals(e.details[0].context.key, "a");
+        t.end();
+    });
+});
+
+
+tap.test('joi - pass joi error - multiple validations - "details" should match those from joi', (t) => {
+    joi.validate({a : 10, b : 'foo'}, schemaC, {abortEarly : false}, (err, result) => {
+        let e = new error.validationError(err);
+        t.equals(e.details.length, 2);
+        t.equals(e.details[0].message, '"a" must be a string');
+        t.equals(e.details[1].message, '"b" must be a number');
+        t.end();
+    });
+});

--- a/test/main.js
+++ b/test/main.js
@@ -35,26 +35,26 @@ tap.test('error() - object should have issue method', (t) => {
 });
 
 
-tap.test('.issue() - set values - values should be set on the ".problem"', (t) => {
+tap.test('.issue() - set values - values should be set on the ".details"', (t) => {
     Object.keys(defs).forEach((name) => {
         let fnName = utils.firstLetterToLowerCase(name);
         let err = new error[fnName]();
         err.issue('foo', 'a');
         err.issue('bar', 'b');
-        t.equal(err.problem.foo, 'a');
-        t.equal(err.problem.bar, 'b');
+        t.equal(err.details.foo, 'a');
+        t.equal(err.details.bar, 'b');
     });
     t.end();
 });
 
 
-tap.test('.issue() - chain metods - values should be set on the ".problem"', (t) => {
+tap.test('.issue() - chain metods - values should be set on the ".details"', (t) => {
     Object.keys(defs).forEach((name) => {
         let fnName = utils.firstLetterToLowerCase(name);
         let err = new error[fnName]();
         err.issue('foo', 'a').issue('bar', 'b');
-        t.equal(err.problem.foo, 'a');
-        t.equal(err.problem.bar, 'b');
+        t.equal(err.details.foo, 'a');
+        t.equal(err.details.bar, 'b');
     });
     t.end();
 });


### PR DESCRIPTION
This PR is a small enhancement of the carrier for details of an error. These details can as is be anything, but they are intended to hold more descriptive details on an error than a stackTrace. These details are more in line of telling exactly what is wrong (ex; parameter "foo" is empty, should be "xxxx") and are intended to be used in a UI for giving an end user / or a service exact info of what is failing.

Its also now possible to pass in a validation error object from [Joi](https://github.com/hapijs/joi) and all its validations details will be kept as is. 

Ex; if a API is returning JSON and a validation is failing (in this example the parameter "a" wants a string, but a number was passed in), the returned http error will look like this:

```json
{                                                                 
  "details": [                                                    
    {                                                             
      "context": {                                                
        "key": "a",
        "value": 10                                               
      },                                                        
      "message": "'a' must be a string",
      "path": "a",
      "type": "string.base"                                       
    }                                                             
  ],
  "message": "Bad Request",
  "statusCode": 400                                               
}  
```